### PR TITLE
Define schema for explainable AI weed recognition page

### DIFF
--- a/explainable_ai_weed.html
+++ b/explainable_ai_weed.html
@@ -1,0 +1,396 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://kbtu.edu.kz/schemas/explainable-ai-weed-recognition.json",
+  "title": "Explainable AI for Weed Recognition under Class Imbalance Webpage",
+  "type": "object",
+  "description": "Schema describing the structure and content requirements for the Explainable AI for Weed Recognition under Class Imbalance project webpage.",
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "description": "Global metadata for the webpage including title and theme colors.",
+      "required": ["title", "subtitle", "theme"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "const": "Explainable AI for Weed Recognition under Class Imbalance"
+        },
+        "subtitle": {
+          "type": "string",
+          "const": "A Proof-of-Concept Deep Learning Framework for Precision Agriculture"
+        },
+        "theme": {
+          "type": "object",
+          "required": ["primary", "background", "textDark", "textMuted"],
+          "properties": {
+            "primary": {
+              "type": "string",
+              "pattern": "^#(?:[0-9a-fA-F]{3}){1,2}$",
+              "const": "#4CAF50"
+            },
+            "background": {
+              "type": "string",
+              "const": "#f4f7f9"
+            },
+            "textDark": {
+              "type": "string",
+              "const": "#222"
+            },
+            "textMuted": {
+              "type": "string",
+              "const": "#555"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "navigation": {
+      "type": "array",
+      "description": "Ordered navigation links appearing in the sticky header.",
+      "minItems": 5,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "required": ["label", "href"],
+        "properties": {
+          "label": {
+            "type": "string",
+            "enum": ["Home", "Architecture", "Results", "Team", "Contact"]
+          },
+          "href": {
+            "type": "string",
+            "pattern": "^#[a-zA-Z0-9_-]+$"
+          }
+        },
+        "additionalProperties": false
+      },
+      "uniqueItems": true
+    },
+    "hero": {
+      "type": "object",
+      "description": "Hero header configuration including background styling and text alignment.",
+      "required": ["layout", "background", "alignment"],
+      "properties": {
+        "layout": {
+          "type": "object",
+          "required": ["padding", "maxWidth"],
+          "properties": {
+            "padding": {
+              "type": "string",
+              "pattern": "^\\d+(rem|px|%)\\s\\d+(rem|px|%)\\s\\d+(rem|px|%)$"
+            },
+            "maxWidth": {
+              "type": "string",
+              "pattern": "^\\d+(px|rem|%)$"
+            }
+          },
+          "additionalProperties": false
+        },
+        "background": {
+          "type": "object",
+          "required": ["type", "values"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["gradient", "texture"]
+            },
+            "values": {
+              "type": "array",
+              "items": { "type": "string" },
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        "alignment": {
+          "type": "string",
+          "enum": ["center", "left"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "abstract": {
+      "type": "object",
+      "description": "Short abstract summarizing the project in three sentences.",
+      "required": ["heading", "body"],
+      "properties": {
+        "heading": {
+          "type": "string",
+          "const": "Abstract"
+        },
+        "body": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "items": {
+            "type": "string",
+            "const": "This project proposes an explainable AI framework for weed recognition under class imbalance, integrating Focal Loss for minority learning and Grad-CAM for interpretability. The system supports precision agriculture by identifying weed species in real field imagery while providing visual transparency for agronomists."
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "architecture": {
+      "type": "object",
+      "description": "Structured infographic grid describing the system architecture layers.",
+      "required": ["layout", "layers"],
+      "properties": {
+        "layout": {
+          "type": "object",
+          "required": ["grid", "cardStyle"],
+          "properties": {
+            "grid": {
+              "type": "object",
+              "required": ["minColumnWidth", "gap"],
+              "properties": {
+                "minColumnWidth": {
+                  "type": "string",
+                  "pattern": "^\\d+(px|rem)$"
+                },
+                "gap": {
+                  "type": "string",
+                  "pattern": "^\\d+(px|rem)$"
+                }
+              },
+              "additionalProperties": false
+            },
+            "cardStyle": {
+              "type": "object",
+              "required": ["borderRadius", "shadow", "hover"],
+              "properties": {
+                "borderRadius": {
+                  "type": "string",
+                  "pattern": "^\\d+(px|rem)$"
+                },
+                "shadow": {
+                  "type": "string"
+                },
+                "hover": {
+                  "type": "object",
+                  "required": ["translate", "shadow"],
+                  "properties": {
+                    "translate": {
+                      "type": "string",
+                      "pattern": "^translateY\\(-?\\d+(px|rem)\\)$"
+                    },
+                    "shadow": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "layers": {
+          "type": "array",
+          "minItems": 6,
+          "maxItems": 6,
+          "items": {
+            "type": "object",
+            "required": ["name", "icon", "description", "focus"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "enum": [
+                  "Data Acquisition Layer",
+                  "Data Preprocessing Layer",
+                  "Model Training Layer",
+                  "Explainability Layer",
+                  "Evaluation Layer",
+                  "Deployment Layer"
+                ]
+              },
+              "icon": {
+                "type": "string",
+                "description": "Emoji or icon identifier representing the layer."
+              },
+              "description": {
+                "type": "string",
+                "minLength": 24,
+                "maxLength": 220
+              },
+              "focus": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1
+              }
+            },
+            "additionalProperties": false
+          },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "results": {
+      "type": "object",
+      "description": "Section summarizing evaluation metrics and visualization links.",
+      "required": ["highlights"],
+      "properties": {
+        "highlights": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 3
+        }
+      },
+      "additionalProperties": false
+    },
+    "team": {
+      "type": "object",
+      "description": "Team members with roles and optional avatars.",
+      "required": ["members"],
+      "properties": {
+        "members": {
+          "type": "array",
+          "minItems": 3,
+          "items": {
+            "type": "object",
+            "required": ["name", "role"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "enum": [
+                  "Askerbay Arman",
+                  "Kumarkhanova Ayazhan",
+                  "Teberikov Nurasyl"
+                ]
+              },
+              "role": {
+                "type": "string"
+              },
+              "contact": {
+                "type": "string",
+                "format": "uri"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "contact": {
+      "type": "object",
+      "description": "Contact options for communication.",
+      "properties": {
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "github": {
+          "type": "string",
+          "format": "uri"
+        },
+        "location": {
+          "type": "string",
+          "const": "Kazakh-British Technical University"
+        }
+      },
+      "additionalProperties": false
+    },
+    "footer": {
+      "type": "object",
+      "description": "Footer content including institution details and year.",
+      "required": ["groupMembers", "institution", "year"],
+      "properties": {
+        "groupMembers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Askerbay Arman",
+              "Kumarkhanova Ayazhan",
+              "Teberikov Nurasyl"
+            ]
+          },
+          "minItems": 3,
+          "maxItems": 3
+        },
+        "institution": {
+          "type": "string",
+          "const": "Kazakh-British Technical University"
+        },
+        "year": {
+          "type": "integer",
+          "const": 2025
+        },
+        "links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["label", "href"],
+            "properties": {
+              "label": {
+                "type": "string",
+                "enum": ["GitHub", "Email"]
+              },
+              "href": {
+                "type": "string",
+                "format": "uri"
+              }
+            },
+            "additionalProperties": false
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "responsiveness": {
+      "type": "object",
+      "description": "Responsive breakpoints ensuring the layout adapts to desktop, tablet, and mobile.",
+      "required": ["breakpoints"],
+      "properties": {
+        "breakpoints": {
+          "type": "array",
+          "minItems": 3,
+          "items": {
+            "type": "object",
+            "required": ["device", "maxWidth", "layoutAdjustments"],
+            "properties": {
+              "device": {
+                "type": "string",
+                "enum": ["desktop", "tablet", "mobile"]
+              },
+              "maxWidth": {
+                "type": "integer",
+                "minimum": 320
+              },
+              "layoutAdjustments": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1
+              }
+            },
+            "additionalProperties": false
+          },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "metadata",
+    "navigation",
+    "hero",
+    "abstract",
+    "architecture",
+    "results",
+    "team",
+    "footer",
+    "responsiveness"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- replace the previous HTML implementation with a JSON Schema that formalizes the structure of the Explainable AI weed recognition webpage
- capture navigation, hero, abstract, architecture layers, results, team, contact, footer, and responsiveness requirements as typed schema properties
- constrain required values such as titles, theme colors, member names, and layout expectations for consistent downstream rendering

## Testing
- python - <<'PY'
import json,sys
with open('explainable_ai_weed.html') as f:
    json.load(f)
print('valid json')
PY

------
https://chatgpt.com/codex/tasks/task_e_68f7cee99cdc8328ba9414cab1122e50